### PR TITLE
Fix Configuration model name clash

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,7 +35,7 @@ class ApplicationController < ActionController::Base
     if session[:user_id].present?
       unless (controller_name == "user") and ["first_login_change_password","login","logout","forgot_password"].include? action_name
         user = User.active.find(session[:user_id])
-        setting = Configuration.get_config_value('FirstTimeLoginEnable')
+        setting = FedenaConfiguration.get_config_value('FirstTimeLoginEnable')
         if setting == "1" and user.is_first_login != false
           flash[:notice] = "#{t('first_login_attempt')}"
           redirect_to :controller => "user",:action => "first_login_change_password",:id => user.username
@@ -53,8 +53,8 @@ class ApplicationController < ActionController::Base
 
   def set_variables
     unless @current_user.nil?
-      @attendance_type = Configuration.get_config_value('StudentAttendanceType') unless @current_user.student?
-      @modules = Configuration.available_modules
+      @attendance_type = FedenaConfiguration.get_config_value('StudentAttendanceType') unless @current_user.student?
+      @modules = FedenaConfiguration.available_modules
     end
   end
 
@@ -172,7 +172,7 @@ class ApplicationController < ActionController::Base
   end
 
   def configuration_settings_for_hr
-    hr = Configuration.find_by_config_value("HR")
+    hr = FedenaConfiguration.find_by_config_value("HR")
     if hr.nil?
       redirect_to :controller => 'user', :action => 'dashboard'
       flash[:notice] = "#{t('flash_msg4')}"
@@ -182,7 +182,7 @@ class ApplicationController < ActionController::Base
   
 
   def configuration_settings_for_finance
-    finance = Configuration.find_by_config_value("Finance")
+    finance = FedenaConfiguration.find_by_config_value("Finance")
     if finance.nil?
       redirect_to :controller => 'user', :action => 'dashboard'
       flash[:notice] = "#{t('flash_msg4')}"
@@ -324,7 +324,7 @@ class ApplicationController < ActionController::Base
     server_time = Time.now
     server_time_to_gmt = server_time.getgm
     @local_tzone_time = server_time
-    time_zone = Configuration.find_by_config_key("TimeZone")
+    time_zone = FedenaConfiguration.find_by_config_key("TimeZone")
     unless time_zone.nil?
       unless time_zone.config_value.nil?
         zone = TimeZone.find(time_zone.config_value)
@@ -344,9 +344,9 @@ class ApplicationController < ActionController::Base
 
   private
   def set_user_language
-    lan = Configuration.find_by_config_key("Locale")
+    lan = FedenaConfiguration.find_by_config_key("Locale")
     I18n.default_locale = :en
-    Translator.fallback(true)
+    # Translator.fallback(true)
     if session[:language].nil?
       I18n.locale = lan.config_value
     else

--- a/app/controllers/archived_employee_controller.rb
+++ b/app/controllers/archived_employee_controller.rb
@@ -22,7 +22,7 @@ class ArchivedEmployeeController < ApplicationController
   filter_access_to :all
 #  prawnto :prawn => {:left_margin => 25, :right_margin => 25}
 
-  
+
 
   def profile
     @current_user = current_user
@@ -95,7 +95,7 @@ class ArchivedEmployeeController < ApplicationController
 
 
   def profile_payroll_details
-    @currency_type = Configuration.find_by_config_key("CurrencyType").config_value
+    @currency_type = FedenaConfiguration.find_by_config_key("CurrencyType").config_value
     @employee = ArchivedEmployee.find(params[:id])
     @payroll_details = ArchivedEmployeeSalaryStructure.find_all_by_employee_id(@employee, :order=>"payroll_category_id ASC")
     render :partial => "payroll_details"
@@ -121,11 +121,11 @@ class ArchivedEmployeeController < ApplicationController
     @office_country = Country.find(@employee.office_country_id).name unless @employee.office_country_id.nil?
     @bank_details = ArchivedEmployeeBankDetail.find_all_by_employee_id(@employee.id)
     @additional_details = ArchivedEmployeeAdditionalDetail.find_all_by_employee_id(@employee.id)
-    
-      render :pdf => 'profile_pdf'
-            
 
-    
+      render :pdf => 'profile_pdf'
+
+
+
   end
 
   def show

--- a/app/controllers/archived_student_controller.rb
+++ b/app/controllers/archived_student_controller.rb
@@ -98,7 +98,7 @@ class ArchivedStudentController < ApplicationController
   end
 
   def student_report
-    @config = Configuration.find_by_config_key('StudentAttendanceType')
+    @config = FedenaConfiguration.find_by_config_key('StudentAttendanceType')
     @student = ArchivedStudent.find(params[:id])
     @batch = Batch.find(params[:year])
     @start_date = @batch.start_date.to_date
@@ -171,7 +171,7 @@ class ArchivedStudentController < ApplicationController
   end
 
   def generated_report_pdf
-    @config = Configuration.get_config_value('InstitutionName')
+    @config = FedenaConfiguration.get_config_value('InstitutionName')
     @exam_group = ExamGroup.find(params[:exam_group])
     @student = ArchivedStudent.find_by_former_id(params[:student])
     @student.id = @student.former_id
@@ -189,7 +189,7 @@ class ArchivedStudentController < ApplicationController
       @exams.push exam unless exam.nil?
     end
     render :pdf => 'generated_report_pdf'
-          
+
     #    respond_to do |format|
     #      format.pdf { render :layout => false }
     #    end
@@ -243,7 +243,7 @@ class ArchivedStudentController < ApplicationController
 
   end
 
-    
+
   def generated_report4_pdf
 
     #grouped-exam-report-for-batch

--- a/app/controllers/attendance_reports_controller.rb
+++ b/app/controllers/attendance_reports_controller.rb
@@ -33,7 +33,7 @@ class AttendanceReportsController < ApplicationController
       @batches+=@current_user.employee_record.subjects.collect{|b| b.batch}
       @batches=@batches.uniq unless @batches.empty?
     end
-    @config = Configuration.find_by_config_key('StudentAttendanceType')
+    @config = FedenaConfiguration.find_by_config_key('StudentAttendanceType')
   end
 
   def subject
@@ -61,7 +61,7 @@ class AttendanceReportsController < ApplicationController
 
   def mode
     @batch = Batch.find params[:batch_id]
-    @config = Configuration.find_by_config_key('StudentAttendanceType')
+    @config = FedenaConfiguration.find_by_config_key('StudentAttendanceType')
     if @config.config_value == 'Daily'
       unless params[:subject_id] == ''
         @subject = params[:subject_id]
@@ -97,7 +97,7 @@ class AttendanceReportsController < ApplicationController
     @end_date = @local_tzone_time.to_date
     @leaves=Hash.new { |h, k| h[k] = Hash.new(&h.default_proc) }
     @mode = params[:mode]
-    @config = Configuration.find_by_config_key('StudentAttendanceType')
+    @config = FedenaConfiguration.find_by_config_key('StudentAttendanceType')
     unless @config.config_value == 'Daily'
       if @mode == 'Overall'
         #        @academic_days=@batch.academic_days.count
@@ -191,7 +191,7 @@ class AttendanceReportsController < ApplicationController
     @month = params[:month]
     @year = params[:year]
     @students = @batch.students.by_first_name
-    @config = Configuration.find_by_config_key('StudentAttendanceType')
+    @config = FedenaConfiguration.find_by_config_key('StudentAttendanceType')
     #    @date = "01-#{@month}-#{@year}"
     @date = '01-'+@month+'-'+@year
     @start_date = @date.to_date
@@ -227,7 +227,7 @@ class AttendanceReportsController < ApplicationController
     @month = params[:month]
     @year = params[:year]
     @students = @batch.students.by_first_name
-    @config = Configuration.find_by_config_key('StudentAttendanceType')
+    @config = FedenaConfiguration.find_by_config_key('StudentAttendanceType')
     #    @date = "01-#{@month}-#{@year}"
     @date = '01-'+@month+'-'+@year
     @start_date = @date.to_date
@@ -300,17 +300,17 @@ class AttendanceReportsController < ApplicationController
   def student_details
     @student = Student.find params[:id]
     @batch = @student.batch
-    @config = Configuration.find_by_config_key('StudentAttendanceType')
+    @config = FedenaConfiguration.find_by_config_key('StudentAttendanceType')
     if @config.config_value == 'Daily'
       @report = Attendance.find(:all,:conditions=>{:student_id=>@student.id,:batch_id=>@batch.id})
     else
       @report = SubjectLeave.find(:all,:conditions=>{:student_id=>@student.id,:batch_id=>@batch.id})
-      
+
     end
   end
 
   def filter
-    @config = Configuration.find_by_config_key('StudentAttendanceType')
+    @config = FedenaConfiguration.find_by_config_key('StudentAttendanceType')
     @batch = Batch.find(params[:filter][:batch])
     @students = @batch.students.by_first_name
     @start_date = (params[:filter][:start_date]).to_date
@@ -378,7 +378,7 @@ class AttendanceReportsController < ApplicationController
   end
 
   def filter2
-    @config = Configuration.find_by_config_key('StudentAttendanceType')
+    @config = FedenaConfiguration.find_by_config_key('StudentAttendanceType')
     @batch = Batch.find(params[:filter][:batch])
     @students = @batch.students.by_first_name
     @start_date = (params[:filter][:start_date]).to_date
@@ -406,7 +406,7 @@ class AttendanceReportsController < ApplicationController
   end
 
   def report_pdf
-    @config = Configuration.find_by_config_key('StudentAttendanceType')
+    @config = FedenaConfiguration.find_by_config_key('StudentAttendanceType')
     @batch = Batch.find(params[:filter][:batch])
     @students = @batch.students.by_first_name
     @start_date = (params[:filter][:start_date]).to_date
@@ -469,7 +469,7 @@ class AttendanceReportsController < ApplicationController
       @report = ''
     end
     render :pdf => 'report_pdf'
-             
+
     #    render :layout=>'pdf'
     #    respond_to do |format|
     #      format.pdf { render :layout => false }
@@ -477,7 +477,7 @@ class AttendanceReportsController < ApplicationController
   end
 
   def filter_report_pdf
-    @config = Configuration.find_by_config_key('StudentAttendanceType')
+    @config = FedenaConfiguration.find_by_config_key('StudentAttendanceType')
     @batch = Batch.find(params[:filter][:batch])
     @students = @batch.students.by_first_name
     @start_date = (params[:filter][:start_date]).to_date
@@ -541,7 +541,7 @@ class AttendanceReportsController < ApplicationController
       end
     end
     render :pdf => 'filter_report_pdf'
-            
+
 
 
     #    respond_to do |format|

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -23,7 +23,7 @@ class AttendancesController < ApplicationController
   before_filter :only_privileged_employee_allowed, :only => 'index'
   before_filter :default_time_zone_present_time
   def index
-    @config = Configuration.find_by_config_key('StudentAttendanceType')
+    @config = FedenaConfiguration.find_by_config_key('StudentAttendanceType')
     @date_today = @local_tzone_time.to_date
     if current_user.admin?
       @batches = Batch.active
@@ -63,7 +63,7 @@ class AttendancesController < ApplicationController
   end
 
   def show
-    @config = Configuration.find_by_config_key('StudentAttendanceType')
+    @config = FedenaConfiguration.find_by_config_key('StudentAttendanceType')
     unless params[:next].nil?
       @today = params[:next].to_date
     else
@@ -170,9 +170,9 @@ class AttendancesController < ApplicationController
       #      format.js { render :action => 'show' }
     end
   end
-  
+
   def new
-    @config = Configuration.find_by_config_key('StudentAttendanceType')
+    @config = FedenaConfiguration.find_by_config_key('StudentAttendanceType')
     if @config.config_value=='Daily'
       @student = Student.find(params[:id])
       @month_date = params[:date]
@@ -188,7 +188,7 @@ class AttendancesController < ApplicationController
   end
 
   def create
-    @config = Configuration.find_by_config_key('StudentAttendanceType')
+    @config = FedenaConfiguration.find_by_config_key('StudentAttendanceType')
     if @config.config_value=="SubjectWise"
       @student = Student.find(params[:subject_leave][:student_id])
       @tte=TimetableEntry.find(params[:timetable_entry])
@@ -198,7 +198,7 @@ class AttendancesController < ApplicationController
       #      @absentee.subject_id=@tte.subject_id
       @absentee.class_timing_id=@tte.class_timing_id
       @absentee.batch_id = @student.batch_id
-      
+
     else
       @student = Student.find(params[:attendance][:student_id])
       @absentee = Attendance.new(params[:attendance])
@@ -243,7 +243,7 @@ class AttendancesController < ApplicationController
   end
 
   def edit
-    @config = Configuration.find_by_config_key('StudentAttendanceType')
+    @config = FedenaConfiguration.find_by_config_key('StudentAttendanceType')
     if @config.config_value=='Daily'
       @absentee = Attendance.find params[:id]
     else
@@ -257,7 +257,7 @@ class AttendancesController < ApplicationController
   end
 
   def update
-    @config = Configuration.find_by_config_key('StudentAttendanceType')
+    @config = FedenaConfiguration.find_by_config_key('StudentAttendanceType')
     if @config.config_value=='Daily'
       @absentee = Attendance.find params[:id]
       @student = Student.find(@absentee.student_id)
@@ -280,7 +280,7 @@ class AttendancesController < ApplicationController
 
 
   def destroy
-    @config = Configuration.find_by_config_key('StudentAttendanceType')
+    @config = FedenaConfiguration.find_by_config_key('StudentAttendanceType')
     if @config.config_value=='Daily'
       @absentee = Attendance.find params[:id]
     else

--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -21,7 +21,7 @@ class BatchesController < ApplicationController
   filter_access_to :all
   before_filter :login_required
   def index
-    @batches = @course.batches    
+    @batches = @course.batches
   end
 
   def new
@@ -126,15 +126,15 @@ class BatchesController < ApplicationController
       end
       flash[:warn_notice] =  err1 + err unless err.empty?
       flash[:fees_import] =  fee_msg unless fee_msg.nil?
-      
+
       redirect_to [@course, @batch]
     else
       @grade_types=[]
-      gpa = Configuration.find_by_config_key("GPA").config_value
+      gpa = FedenaConfiguration.find_by_config_key("GPA").config_value
       if gpa == "1"
         @grade_types << "GPA"
       end
-      cwa = Configuration.find_by_config_key("CWA").config_value
+      cwa = FedenaConfiguration.find_by_config_key("CWA").config_value
       if cwa == "1"
         @grade_types << "CWA"
       end

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -24,26 +24,26 @@ class ConfigurationController < ApplicationController
   FILE_MAXIMUM_SIZE_FOR_FILE=1048576
 
   def settings
-    @config = Configuration.get_multiple_configs_as_hash ['InstitutionName', 'InstitutionAddress', 'InstitutionPhoneNo', \
+    @config = FedenaConfiguration.get_multiple_configs_as_hash ['InstitutionName', 'InstitutionAddress', 'InstitutionPhoneNo', \
         'StudentAttendanceType', 'CurrencyType', 'ExamResultType', 'AdmissionNumberAutoIncrement','EmployeeNumberAutoIncrement', \
         'NetworkState','Locale','FinancialYearStartDate','FinancialYearEndDate','EnableNewsCommentModeration','DefaultCountry','TimeZone','FirstTimeLoginEnable']
     @grading_types = Course::GRADINGTYPES
-    @enabled_grading_types = Configuration.get_grading_types
+    @enabled_grading_types = FedenaConfiguration.get_grading_types
     @time_zones = TimeZone.all
     @school_detail = SchoolDetail.first || SchoolDetail.new
     @countries=Country.all
     if request.post?
-      Configuration.set_config_values(params[:configuration])
+      FedenaConfiguration.set_config_values(params[:configuration])
       session[:language] = nil unless session[:language].nil?
       @school_detail.logo = params[:school_detail][:school_logo] if params[:school_detail].present?
       unless @school_detail.save
-        @config = Configuration.get_multiple_configs_as_hash ['InstitutionName', 'InstitutionAddress', 'InstitutionPhoneNo', \
+        @config = FedenaConfiguration.get_multiple_configs_as_hash ['InstitutionName', 'InstitutionAddress', 'InstitutionPhoneNo', \
             'StudentAttendanceType', 'CurrencyType', 'ExamResultType', 'AdmissionNumberAutoIncrement','EmployeeNumberAutoIncrement', \
             'NetworkState','Locale','FinancialYearStartDate','FinancialYearEndDate','EnableNewsCommentModeration','DefaultCountry','TimeZone','FirstTimeLoginEnable']
         return
       end
       @current_user.clear_menu_cache
-      Configuration.clear_school_cache(@current_user)
+      FedenaConfiguration.clear_school_cache(@current_user)
       News.new.reload_news_bar
       flash[:notice] = "#{t('flash_msg8')}"
       redirect_to :action => "settings"  and return

--- a/app/controllers/employee_attendance_controller.rb
+++ b/app/controllers/employee_attendance_controller.rb
@@ -62,16 +62,16 @@ class EmployeeAttendanceController < ApplicationController
             flash[:notice] = "#{t('flash_msg12')}"
     end
     redirect_to :action => "add_leave_types"
-    
+
 
   end
 
   def leave_reset_settings
     #  @config = Configuration.get_multiple_configs_as_hash ['AutomaticLeaveReset', 'LeaveResetPeriod', 'LastAutoLeaveReset']
-    @auto_reset = Configuration.find_by_config_key('AutomaticLeaveReset')
-    @reset_period = Configuration.find_by_config_key('LeaveResetPeriod')
-    @last_reset = Configuration.find_by_config_key('LastAutoLeaveReset')
-    @fin_start_date = Configuration.find_by_config_key('FinancialYearStartDate')
+    @auto_reset = FedenaConfiguration.find_by_config_key('AutomaticLeaveReset')
+    @reset_period = FedenaConfiguration.find_by_config_key('LeaveResetPeriod')
+    @last_reset = FedenaConfiguration.find_by_config_key('LastAutoLeaveReset')
+    @fin_start_date = FedenaConfiguration.find_by_config_key('FinancialYearStartDate')
     if request.post?
       @auto_reset.update_attributes(:config_value=> params[:configuration][:automatic_leave_reset])
       @reset_period.update_attributes(:config_value=> params[:configuration][:leave_reset_period])
@@ -80,7 +80,7 @@ class EmployeeAttendanceController < ApplicationController
             flash[:notice] = t('flash_msg8')
         end
     end
- 
+
   def update_employee_leave_reset_all
     @leave_count = EmployeeLeave.all
     @leave_count.each do |e|
@@ -389,7 +389,7 @@ class EmployeeAttendanceController < ApplicationController
       start_date = @applied_leave.start_date
       end_date = @applied_leave.end_date
       (start_date..end_date).each do |d|
-      
+
         unless(d.strftime('%A') == "Sunday")
           EmployeeAttendance.create(:attendance_date=>d, :employee_id=>@applied_employee.id,:employee_leave_type_id=>@applied_leave.employee_leave_types_id, :reason => @applied_leave.reason, :is_half_day => @applied_leave.is_half_day)
           att = EmployeeAttendance.find_by_attendance_date(d)
@@ -406,7 +406,7 @@ class EmployeeAttendanceController < ApplicationController
         end
       end
     end
-    
+
         flash[:notice]="#{t('flash6')} #{@applied_employee.first_name} from #{@applied_leave.start_date} to #{@applied_leave.end_date}"
     redirect_to :controller=>"employee_attendance", :action=>"leaves", :id=>@manager
   end
@@ -496,7 +496,7 @@ class EmployeeAttendanceController < ApplicationController
       @total_leaves = @total_leaves + leave_count
     end
     render :pdf => 'employee_attendance_pdf'
-          
+
 
     #        respond_to do |format|
     #            format.pdf { render :layout => false }

--- a/app/controllers/employee_controller.rb
+++ b/app/controllers/employee_controller.rb
@@ -32,13 +32,13 @@ class EmployeeController < ApplicationController
       redirect_to :controller => "employee", :action => "add_category"
     end
   end
-  
+
   def edit_category
     @category = EmployeeCategory.find(params[:id])
     employees = Employee.find(:all ,:conditions=>"employee_category_id = #{params[:id]}")
     if request.post?
       if (params[:category][:status] == 'false' and employees.blank?) or params[:category][:status] == 'true'
-        
+
         if @category.update_attributes(params[:category])
           unless @category.status
             position = EmployeePosition.find_all_by_employee_category_id(@category.id)
@@ -52,7 +52,7 @@ class EmployeeController < ApplicationController
       else
         flash[:warn_notice] = "<p>#{t('flash2')}</p>"
       end
-      
+
     end
   end
 
@@ -245,7 +245,7 @@ class EmployeeController < ApplicationController
       end
     end
   end
-  
+
   def change_field_priority
     @additional_field = AdditionalField.find(params[:id])
     priority = @additional_field.priority
@@ -310,9 +310,9 @@ class EmployeeController < ApplicationController
     @departments = EmployeeDepartment.find(:all,:order => "name asc",:conditions => "status = true")
     @nationalities = Country.all
     @employee = Employee.new(params[:employee])
-    @selected_value = Configuration.default_country
+    @selected_value = FedenaConfiguration.default_country
     @last_admitted_employee = Employee.find(:last,:conditions=>"employee_number != 'admin'")
-    @config = Configuration.find_by_config_key('EmployeeNumberAutoIncrement')
+    @config = FedenaConfiguration.find_by_config_key('EmployeeNumberAutoIncrement')
 
     if request.post?
 
@@ -389,7 +389,7 @@ class EmployeeController < ApplicationController
   def admission2
     @countries = Country.find(:all)
     @employee = Employee.find(params[:id])
-    @selected_value = Configuration.default_country
+    @selected_value = FedenaConfiguration.default_country
     if request.post? and @employee.update_attributes(params[:employee])
       sms_setting = SmsSetting.new()
       if sms_setting.application_sms_active and sms_setting.employee_sms_active
@@ -401,7 +401,7 @@ class EmployeeController < ApplicationController
       redirect_to :action => "admission3", :id => @employee.id
     end
   end
-  
+
   def edit2
     @employee = Employee.find(params[:id])
     @countries = Country.find(:all)
@@ -436,7 +436,7 @@ class EmployeeController < ApplicationController
       redirect_to :action => "admission3_1", :id => @employee.id
     end
   end
-  
+
   def edit3
     @employee = Employee.find(params[:id])
     @bank_fields = BankField.find(:all, :conditions=>"status = true")
@@ -526,9 +526,9 @@ class EmployeeController < ApplicationController
   def edit_privilege
     @user = User.active.find_by_username(params[:id])
     @employee = @user.employee_record
-    @finance = Configuration.find_by_config_value("Finance")
+    @finance = FedenaConfiguration.find_by_config_value("Finance")
     @sms_setting = SmsSetting.application_sms_status
-    @hr = Configuration.find_by_config_value("HR")
+    @hr = FedenaConfiguration.find_by_config_value("HR")
     @privilege_tags=PrivilegeTag.find(:all,:order=>"priority ASC")
     @user_privileges=@user.privileges
     if request.post?
@@ -538,7 +538,7 @@ class EmployeeController < ApplicationController
       redirect_to :action => 'admission4',:id => @employee.id
     end
   end
-  
+
   def edit3_1
     @employee = Employee.find(params[:id])
     @additional_fields = AdditionalField.find(:all, :conditions=>"status = true")
@@ -572,7 +572,7 @@ class EmployeeController < ApplicationController
       flash[:notice]=t('flash25')
       redirect_to :controller => "payroll", :action => "manage_payroll", :id=>@employee.id
     end
-  
+
   end
 
   def view_rep_manager
@@ -732,7 +732,7 @@ class EmployeeController < ApplicationController
 
 
   def profile_payroll_details
-    @currency_type = Configuration.find_by_config_key("CurrencyType").config_value
+    @currency_type = FedenaConfiguration.find_by_config_key("CurrencyType").config_value
     @employee = Employee.find(params[:id])
     @payroll_details = EmployeeSalaryStructure.find_all_by_employee_id(@employee, :order=>"payroll_category_id ASC")
     render :partial => "payroll_details"
@@ -764,8 +764,8 @@ class EmployeeController < ApplicationController
     @bank_details = EmployeeBankDetail.find_all_by_employee_id(@employee.id)
     @additional_details = EmployeeAdditionalDetail.find_all_by_employee_id(@employee.id)
     render :pdf => 'profile_pdf'
-          
-            
+
+
     #    respond_to do |format|
     #      format.pdf { render :layout => false }
     #    end
@@ -887,7 +887,7 @@ class EmployeeController < ApplicationController
         flash[:warn_notice] = "#{t('flash45')} #{params[:salary_date]}"
       end
     end
-    
+
   end
 
   def view_payslip
@@ -897,7 +897,7 @@ class EmployeeController < ApplicationController
   end
 
   def update_monthly_payslip
-    @currency_type = Configuration.find_by_config_key("CurrencyType").config_value
+    @currency_type = FedenaConfiguration.find_by_config_key("CurrencyType").config_value
     @salary_date = params[:salary_date]
     if params[:salary_date] == ""
       render :update do |page|
@@ -1134,7 +1134,7 @@ class EmployeeController < ApplicationController
     @employee_additional_categories = IndividualPayslipCategory.find_all_by_employee_id(@employee.id, :conditions=>"include_every_month = true")
     @new_payslip_category = IndividualPayslipCategory.find_all_by_employee_id_and_salary_date(@employee.id,nil)
     @user = current_user
-    
+
 
     if request.post?
       salary_date = Date.parse(params[:salary_date])
@@ -1145,7 +1145,7 @@ class EmployeeController < ApplicationController
       payslip_exists.each do |p|
         p.delete
       end
-      
+
       params[:manage_payroll].each_pair do |k, v|
         row_id = EmployeeSalaryStructure.find_by_employee_id_and_payroll_category_id(@employee, k)
         category_name = PayrollCategory.find(k).name
@@ -1171,13 +1171,13 @@ class EmployeeController < ApplicationController
           :body=>body ))
       flash[:notice] = "#{@employee.first_name} #{t('flash27')} #{params[:salary_date]}"
       redirect_to :controller => "employee", :action => "profile", :id=> @employee.id
-      
+
     end
   end
   def update_rejected_payslip
     @salary_date = params[:salary_date]
     @employee = Employee.find(params[:emp_id])
-    @currency_type = Configuration.find_by_config_key("CurrencyType").config_value
+    @currency_type = FedenaConfiguration.find_by_config_key("CurrencyType").config_value
 
     if params[:salary_date] == ""
       render :update do |page|
@@ -1254,7 +1254,7 @@ class EmployeeController < ApplicationController
 
     @user = current_user
     finance_manager = find_finance_managers
-    finance = Configuration.find_by_config_value("Finance")
+    finance = FedenaConfiguration.find_by_config_value("Finance")
     subject = "#{t('payslip_generated')}"
     body = "#{t('message_body')}"
     salary_date = Date.parse(params[:salary_date])
@@ -1440,9 +1440,9 @@ class EmployeeController < ApplicationController
     @employees = Employee.find_all_by_employee_department_id(@department.id)
 
 
-    @currency_type = Configuration.find_by_config_key("CurrencyType").config_value
+    @currency_type = FedenaConfiguration.find_by_config_key("CurrencyType").config_value
     @salary_date = params[:salary_date] if params[:salary_date]
-   
+
     render :pdf => 'department_payslip_pdf',
       :margin => {    :top=> 10,
       :bottom => 10,
@@ -1457,7 +1457,7 @@ class EmployeeController < ApplicationController
   def individual_payslip_pdf
     @employee = Employee.find(params[:id])
     @department = EmployeeDepartment.find(@employee.employee_department_id).name
-    @currency_type = Configuration.find_by_config_key("CurrencyType").config_value
+    @currency_type = FedenaConfiguration.find_by_config_key("CurrencyType").config_value
     @category = EmployeeCategory.find(@employee.employee_category_id).name
     @grade = EmployeeGrade.find(@employee.employee_grade_id).name unless @employee.employee_grade_id.nil?
     @position = EmployeePosition.find(@employee.employee_position_id).name
@@ -1504,7 +1504,7 @@ class EmployeeController < ApplicationController
 
     @net_amount = @net_non_deductionable_amount - @net_deductionable_amount
     render :pdf => 'individual_payslip_pdf'
-    
+
 
     #    respond_to do |format|
     #      format.pdf { render :layout => false }
@@ -1519,7 +1519,7 @@ class EmployeeController < ApplicationController
     @bank_details = EmployeeBankDetail.find_all_by_employee_id(@employee.id)
     @employee ||= ArchivedEmployee.find(:first,:conditions=>"former_id=#{params[:id]}")
     @department = EmployeeDepartment.find(@employee.employee_department_id).name
-    @currency_type = Configuration.find_by_config_key("CurrencyType").config_value
+    @currency_type = FedenaConfiguration.find_by_config_key("CurrencyType").config_value
     @category = EmployeeCategory.find(@employee.employee_category_id).name
     @grade = EmployeeGrade.find(@employee.employee_grade_id).name unless @employee.employee_grade_id.nil?
     @position = EmployeePosition.find(@employee.employee_position_id).name
@@ -1565,7 +1565,7 @@ class EmployeeController < ApplicationController
     @net_deductionable_amount = @individual_category_deductionable + @deductionable_amount
 
     @net_amount = @net_non_deductionable_amount - @net_deductionable_amount
-    
+
     render :pdf => 'individual_payslip_pdf'
     #    respond_to do |format|
     #      format.pdf { render :layout => false }

--- a/app/controllers/exam_controller.rb
+++ b/app/controllers/exam_controller.rb
@@ -21,7 +21,7 @@ class ExamController < ApplicationController
   before_filter :protect_other_student_data
   before_filter :restrict_employees_from_exam
   filter_access_to :all
-  
+
   def index
   end
 
@@ -55,7 +55,7 @@ class ExamController < ApplicationController
           page.replace_html 'flash', :text=>''
         end
       end
-      
+
     else
       render(:update) do |page|
         page.replace_html 'flash', :text=>"<div class='errorExplanation'><p>#{t('flash_msg9')}</p></div>"
@@ -312,7 +312,7 @@ class ExamController < ApplicationController
   end
 
   def generated_report_pdf
-    @config = Configuration.get_config_value('InstitutionName')
+    @config = FedenaConfiguration.get_config_value('InstitutionName')
     @exam_group = ExamGroup.find(params[:exam_group])
     @batch = Batch.find(params[:batch])
     @students = @batch.students.by_first_name
@@ -405,7 +405,7 @@ class ExamController < ApplicationController
     @students = @batch.students
     @exam_groups = ExamGroup.find(:all,:conditions=>{:batch_id=>@batch.id})
     render :pdf => 'generated_report_pdf'
-    
+
     #        respond_to do |format|
     #            format.pdf { render :layout => false }
     #        end
@@ -430,7 +430,7 @@ class ExamController < ApplicationController
     @ranked_students = @batch.find_batch_rank
     render :pdf => "student_batch_rank_pdf"
   end
-  
+
   def course_rank
   end
 
@@ -1181,14 +1181,14 @@ class ExamController < ApplicationController
     end
 
   end
-  
+
   def previous_years_marks_overview_pdf
     @student = Student.find(params[:student])
     @all_batches = @student.all_batches
     render :pdf => 'previous_years_marks_overview_pdf',
       :orientation => 'Landscape'
-    
-    
+
+
   end
 
   def academic_report
@@ -1293,7 +1293,7 @@ class ExamController < ApplicationController
     @ordered_students.each do|s|
       @students.push s[2]
     end
-    @config = Configuration.get_config_value('ExamResultType') || 'Marks'
+    @config = FedenaConfiguration.get_config_value('ExamResultType') || 'Marks'
 
     @grades = @batch.grading_level_list
   end
@@ -1364,7 +1364,7 @@ class ExamController < ApplicationController
 
   end
 
-  
+
   #GRAPHS
 
   def graph_for_generated_report
@@ -1529,4 +1529,3 @@ class ExamController < ApplicationController
   end
 
 end
-

--- a/app/controllers/exams_controller.rb
+++ b/app/controllers/exams_controller.rb
@@ -115,7 +115,7 @@ class ExamsController < ApplicationController
         @students.push s[2]
       end
     end
-    @config = Configuration.get_config_value('ExamResultType') || 'Marks'
+    @config = FedenaConfiguration.get_config_value('ExamResultType') || 'Marks'
 
     @grades = @batch.grading_level_list
   end

--- a/app/controllers/grading_levels_controller.rb
+++ b/app/controllers/grading_levels_controller.rb
@@ -30,7 +30,7 @@ class GradingLevelsController < ApplicationController
     if @batch.present?
       @credit = @batch.gpa_enabled? || @batch.cce_enabled?
     else
-      @credit = Configuration.cce_enabled? || Configuration.get_config_value('CWA')=='1' || Configuration.get_config_value('GPA')=='1'
+      @credit = FedenaConfiguration.cce_enabled? || FedenaConfiguration.get_config_value('CWA')=='1' || FedenaConfiguration.get_config_value('GPA')=='1'
     end
     respond_to do |format|
       format.js { render :action => 'new' }
@@ -62,7 +62,7 @@ class GradingLevelsController < ApplicationController
     if @batch.present?
       @credit = @batch.gpa_enabled? || @batch.cce_enabled?
     else
-      @credit = Configuration.get_config_value('CCE')=='1' || Configuration.get_config_value('CWA')=='1' || Configuration.get_config_value('GPA')=='1'
+      @credit = FedenaConfiguration.get_config_value('CCE')=='1' || FedenaConfiguration.get_config_value('CWA')=='1' || FedenaConfiguration.get_config_value('GPA')=='1'
     end
     respond_to do |format|
       format.html { }

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -37,7 +37,7 @@ class NewsController < ApplicationController
     @cmnt = NewsComment.new(params[:comment])
     @cmnt.author = current_user
     @cmnt.is_approved =true if @current_user.privileges.include?(Privilege.find_by_name('ManageNews')) || @current_user.admin?
-    @config = Configuration.find_by_config_key('EnableNewsCommentModeration') 
+    @config = FedenaConfiguration.find_by_config_key('EnableNewsCommentModeration')
     @cmnt.save
   end
 
@@ -84,7 +84,7 @@ class NewsController < ApplicationController
     @news = News.find(params[:id])
     @comments = @news.comments
     @is_moderator = @current_user.privileges.include?(Privilege.find_by_name('ManageNews')) || @current_user.admin?
-    @config = Configuration.find_by_config_key('EnableNewsCommentModeration') 
+    @config = FedenaConfiguration.find_by_config_key('EnableNewsCommentModeration')
   end
 
   def comment_approved

--- a/app/controllers/sms_controller.rb
+++ b/app/controllers/sms_controller.rb
@@ -19,7 +19,7 @@
 class SmsController < ApplicationController
   before_filter :login_required
   filter_access_to :all
-  
+
   def index
     @sms_setting = SmsSetting.new()
     @parents_sms_enabled = SmsSetting.find_by_settings_key("ParentSmsEnabled")
@@ -70,7 +70,7 @@ class SmsController < ApplicationController
           student = Student.find(s_id)
           guardian = student.immediate_contact
           if student.is_sms_enabled
-            if sms_setting.student_sms_active           
+            if sms_setting.student_sms_active
               @recipients.push student.phone2 unless (student.phone2.nil? or student.phone2 == "")
             end
             if sms_setting.parent_sms_active
@@ -92,7 +92,7 @@ class SmsController < ApplicationController
       end
     end
   end
-  
+
   def list_students
     batch = Batch.find(params[:batch_id])
     @students = Student.find_all_by_batch_id(batch.id,:conditions=>'is_sms_enabled=true')
@@ -233,7 +233,7 @@ class SmsController < ApplicationController
 
   def show_sms_messages
     @sms_messages = SmsMessage.get_sms_messages(params[:page])
-    @total_sms = Configuration.get_config_value("TotalSmsCount")
+    @total_sms = FedenaConfiguration.get_config_value("TotalSmsCount")
   end
 
   def show_sms_logs

--- a/app/controllers/student_attendance_controller.rb
+++ b/app/controllers/student_attendance_controller.rb
@@ -21,12 +21,12 @@ class StudentAttendanceController < ApplicationController
   before_filter :only_assigned_employee_allowed
   before_filter :protect_other_student_data
   filter_access_to :all
- 
+
   def index
   end
 
   def student
-    @config = Configuration.find_by_config_key('StudentAttendanceType')
+    @config = FedenaConfiguration.find_by_config_key('StudentAttendanceType')
     @student = Student.find(params[:id])
     @batch = Batch.find(@student.batch_id)
     @subjects = Subject.find_all_by_batch_id(@batch.id,:conditions=>'is_deleted = false')
@@ -101,13 +101,13 @@ class StudentAttendanceController < ApplicationController
         end
         return
       end
-      
+
       render :update do |page|
         page.replace_html 'report', :partial => 'report'
         page.replace_html 'error-container', :text => ''
       end
     end
-    
+
   end
 
   def month
@@ -126,7 +126,7 @@ class StudentAttendanceController < ApplicationController
   end
 
   def student_report
-    @config = Configuration.find_by_config_key('StudentAttendanceType')
+    @config = FedenaConfiguration.find_by_config_key('StudentAttendanceType')
     @student = Student.find(params[:id])
     @batch = Batch.find(params[:year])
     @start_date = @batch.start_date.to_date

--- a/app/controllers/timetable_controller.rb
+++ b/app/controllers/timetable_controller.rb
@@ -476,7 +476,7 @@ class TimetableController < ApplicationController
     @subjects = @batches.collect(&:subjects).flatten
   end
   def timetable
-    @config = Configuration.available_modules
+    @config = FedenaConfiguration.available_modules
     @batches = Batch.active
     unless params[:next].nil?
       @today = params[:next].to_date
@@ -487,7 +487,7 @@ class TimetableController < ApplicationController
       @today = @local_tzone_time.to_date
     end
   end
-  
+
 end
 class Hash
   def delete_blank

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -84,7 +84,7 @@ module ApplicationHelper
   end
 
   def currency
-    Configuration.find_by_config_key("CurrencyType").config_value
+    FedenaConfiguration.find_by_config_key("CurrencyType").config_value
   end
 
   def pdf_image_tag(image, options = {})
@@ -116,7 +116,7 @@ module ApplicationHelper
 
   def current_school_name
     Rails.cache.fetch("current_school_name#{session[:user_id]}"){
-      Configuration.get_config_value('InstitutionName')
+      FedenaConfiguration.get_config_value('InstitutionName')
     }
   end
 

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -267,11 +267,11 @@ class Batch < ActiveRecord::Base
   end
 
   def gpa_enabled?
-    Configuration.has_gpa? and self.grading_type=="1"
+    FedenaConfiguration.has_gpa? and self.grading_type=="1"
   end
 
   def cwa_enabled?
-    Configuration.has_cwa? and self.grading_type=="2"
+    FedenaConfiguration.has_cwa? and self.grading_type=="2"
   end
 
   def normal_enabled?
@@ -580,7 +580,7 @@ class Batch < ActiveRecord::Base
         hsh[k]=val.group_by(&:day_of_week)
       end
       timetables.each do |tt|
-        ([starting_date,start_date.to_date,tt.start_date].max..[tt.end_date,end_date.to_date,ending_date,Configuration.default_time_zone_present_time.to_date].min).each do |d|
+        ([starting_date,start_date.to_date,tt.start_date].max..[tt.end_date,end_date.to_date,ending_date,FedenaConfiguration.default_time_zone_present_time.to_date].min).each do |d|
           hsh2[d]=hsh[tt.id][d.wday]
         end
       end
@@ -664,11 +664,11 @@ class Batch < ActiveRecord::Base
     else
       generate_cce_reports
     end
-    prev_record = Configuration.find_by_config_key("job/Batch/#{self.job_type}")
+    prev_record = FedenaConfiguration.find_by_config_key("job/Batch/#{self.job_type}")
     if prev_record.present?
       prev_record.update_attributes(:config_value=>Time.now)
     else
-      Configuration.create(:config_key=>"job/Batch/#{self.job_type}", :config_value=>Time.now)
+      FedenaConfiguration.create(:config_key=>"job/Batch/#{self.job_type}", :config_value=>Time.now)
     end
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -104,15 +104,15 @@ class Course < ActiveRecord::Base
   end
 
   def cce_enabled?
-    Configuration.cce_enabled? and grading_type == "3"
+    FedenaConfiguration.cce_enabled? and grading_type == "3"
   end
 
   def gpa_enabled?
-    Configuration.has_gpa? and self.grading_type=="1"
+    FedenaConfiguration.has_gpa? and self.grading_type=="1"
   end
 
   def cwa_enabled?
-    Configuration.has_cwa? and self.grading_type=="2"
+    FedenaConfiguration.has_cwa? and self.grading_type=="2"
   end
 
   def normal_enabled?
@@ -139,7 +139,7 @@ class Course < ActiveRecord::Base
     def grading_types
       hsh =  ActiveSupport::OrderedHash.new
       hsh["0"]="Normal"
-      types = Configuration.get_grading_types
+      types = FedenaConfiguration.get_grading_types
       types.each{|t| hsh[t] = GRADINGTYPES[t]}
       hsh
     end

--- a/app/models/fedena_configuration.rb
+++ b/app/models/fedena_configuration.rb
@@ -16,11 +16,12 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
-class Configuration < ActiveRecord::Base
+class FedenaConfiguration < ActiveRecord::Base
+  self.table_name = 'configurations'
 
-  STUDENT_ATTENDANCE_TYPE_OPTIONS = [["#{t('daily_text')}", "Daily"], ["#{t('subject_wise_text')}", "SubjectWise"]]
+  STUDENT_ATTENDANCE_TYPE_OPTIONS = [["#{I18n.t('daily_text')}", "Daily"], ["#{I18n.t('subject_wise_text')}", "SubjectWise"]]
 
-  NETWORK_STATES                   = [["#{t('online')}",'Online'],["#{t('offline')}",'Offline']]
+  NETWORK_STATES                   = [["#{I18n.t('online')}",'Online'],["#{I18n.t('offline')}",'Offline']]
   LOCALES = []
   Dir.glob("#{Rails.root}/config/locales/*.yml").each do |file|
     file.gsub!("#{Rails.root}/config/locales/", '')
@@ -30,7 +31,7 @@ class Configuration < ActiveRecord::Base
 
   def validate
     if self.config_key == "StudentAttendanceType"
-      errors.add_to_base("#{t('student_attendance_type_should_be_one')} #{STUDENT_ATTENDANCE_TYPE_OPTIONS}") unless Configuration::STUDENT_ATTENDANCE_TYPE_OPTIONS.collect{|d| d[1] == self.config_value}.include?(true)
+      errors.add_to_base("#{t('student_attendance_type_should_be_one')} #{STUDENT_ATTENDANCE_TYPE_OPTIONS}") unless FedenaConfiguration::STUDENT_ATTENDANCE_TYPE_OPTIONS.collect{|d| d[1] == self.config_value}.include?(true)
     end
     if self.config_key == "NetworkState"
       errors.add_to_base("#{t('network_state_should_be_one')} #{NETWORK_STATES}") unless NETWORK_STATES.collect{|d| d[1] == self.config_value}.include?(true)
@@ -66,7 +67,7 @@ class Configuration < ActiveRecord::Base
     def set_value(key, value)
       config = find_by_config_key(key)
       config.nil? ?
-        Configuration.create(:config_key => key, :config_value => value) :
+        FedenaConfiguration.create(:config_key => key, :config_value => value) :
         config.update_attribute(:config_value, value)
     end
 
@@ -103,7 +104,7 @@ class Configuration < ActiveRecord::Base
       server_time = Time.now
       server_time_to_gmt = server_time.getgm
       local_tzone_time = server_time
-      time_zone = Configuration.find_by_config_key("TimeZone")
+      time_zone = FedenaConfiguration.find_by_config_key("TimeZone")
       unless time_zone.nil?
         unless time_zone.config_value.nil?
           zone = TimeZone.find(time_zone.config_value)

--- a/app/models/finance/finance_transaction.rb
+++ b/app/models/finance/finance_transaction.rb
@@ -62,12 +62,12 @@ class FinanceTransaction < ActiveRecord::Base
     #    donations = FinanceTransaction.find(:all,
     #      :conditions => ["transaction_date >= '#{start_date}' and transaction_date <= '#{end_date}'and category_id ='#{donation_id}'"])
     trigger = FinanceTransactionTrigger.find(:all)
-    hr = Configuration.find_by_config_value("HR")
+    hr = FedenaConfiguration.find_by_config_value("HR")
     income_total = 0
     expenses_total = 0
     fees_total =0
     salary = 0
-     
+
     unless hr.nil?
       salary = MonthlyPayslip.total_employees_salary(start_date, end_date)
       expenses_total += salary[:total_salary].to_f
@@ -82,7 +82,7 @@ class FinanceTransaction < ActiveRecord::Base
       else
         expenses_total +=d.amount
       end
-      
+
     end
     transactions_fees.each do |fees|
       income_total +=fees.amount
@@ -104,7 +104,7 @@ class FinanceTransaction < ActiveRecord::Base
         end
       end
     end
-    
+
     other_transactions.each do |t|
       if t.category.is_income? and t.master_transaction_id == 0
         income_total +=t.amount
@@ -113,7 +113,7 @@ class FinanceTransaction < ActiveRecord::Base
       end
     end
     income_total-expenses_total
-    
+
   end
 
   def self.total_fees(start_date,end_date)
@@ -165,7 +165,7 @@ class FinanceTransaction < ActiveRecord::Base
       #end
     end
     donations_income-donations_expenses
-    
+
   end
 
 
@@ -228,7 +228,7 @@ class FinanceTransaction < ActiveRecord::Base
     transactions.each {|transaction| amount += transaction.amount}
     return {:amount=>amount,:category_type=>category_type}
   end
-  
+
   def add_voucher_or_receipt_number
     if self.category.is_income and self.master_transaction_id == 0
       last_transaction = FinanceTransaction.last(:conditions=>"receipt_no IS NOT NULL")

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -16,5 +16,5 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 class Language < ActiveRecord::Base
- scope :translation_available, :conditions => { :code => Configuration::LOCALES }
+ scope :translation_available, :conditions => { :code => FedenaConfiguration::LOCALES }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -99,7 +99,7 @@ class User < ActiveRecord::Base
       employee = employee_record
       unless employee.nil?
         if employee.subjects.present?
-          prv << :subject_attendance if Configuration.get_config_value('StudentAttendanceType') == 'SubjectWise'
+          prv << :subject_attendance if FedenaConfiguration.get_config_value('StudentAttendanceType') == 'SubjectWise'
           prv << :subject_exam
         end
         if Batch.active.collect(&:employee_id).include?(employee.id.to_s)

--- a/app/views/archived_student/reports.erb
+++ b/app/views/archived_student/reports.erb
@@ -59,7 +59,7 @@
         <% else %>
           <li><%= link_to "Transcript Report", { :controller=>'exam', :action => 'student_transcript',:transcript=>{:batch_id=>@student.batch_id},:student_id=>@student.former_id,:flag=>"1" } %></li>
         <% end %>
-        <% if Configuration.cce_enabled? %>
+        <% if FedenaConfiguration.cce_enabled? %>
           <li><%= link_to "CCE Transcript Report", { :controller => 'cce_reports', :action => 'student_transcript',:id=>@student.id, :type=>"former" }%></li>
         <% end %>
 

--- a/app/views/attendances/_attendance_cell.html.erb
+++ b/app/views/attendances/_attendance_cell.html.erb
@@ -17,7 +17,7 @@
 #specific language governing permissions and limitations
 #under the License. -%>
 
-<% if Configuration.find_by_config_key('StudentAttendanceType').config_value=='Daily' %>
+<% if FedenaConfiguration.find_by_config_key('StudentAttendanceType').config_value=='Daily' %>
   <% @absent = Attendance.find_by_student_id_and_month_date(@student.id, @absentee.month_date) %>
   <% unless @absent.nil? %>
     <%#= link_to_remote('X', {:url => edit_attendance_path(@absent), :method => 'get'}, :class=> 'absent') %>

--- a/app/views/cce_settings/index.html.erb
+++ b/app/views/cce_settings/index.html.erb
@@ -38,7 +38,7 @@
 
   <div class="box">
 
-    <% if Configuration.find_by_config_key("CCE").config_value=="1" %>
+    <% if FedenaConfiguration.find_by_config_key("CCE").config_value=="1" %>
       <div class="link-box">
         <div class="link-heading"><%= link_to t("basic_settings"),:action=>'basic' %></div>
         <div class="link-descr"><%= t("basic_setting_descr") %></div>
@@ -55,4 +55,3 @@
     <div class="extender"></div>
   </div>
 </div>
-

--- a/app/views/configuration/settings.html.erb
+++ b/app/views/configuration/settings.html.erb
@@ -148,7 +148,7 @@
         <%= check_box :configuration, :admission_number_auto_increment, :checked => false %><%= t('student_admission_auto') %>
       <% end %>
       <br/>
-      <% if Configuration.available_modules.include?('HR') %>
+      <% if FedenaConfiguration.available_modules.include?('HR') %>
         <% if @config[:employee_number_auto_increment] == '1' %>
           <%= check_box :configuration, :employee_number_auto_increment, :checked => true %> <%= t('employee_admission_auto') %>
         <% else %>

--- a/app/views/employee/hr.erb
+++ b/app/views/employee/hr.erb
@@ -72,7 +72,7 @@
       <div class="link-descr"><%= "#{t('view_department_wise_payslip')}" %></div>
     </div>
     <% end %>
-    <% finance = Configuration.available_modules %>
+    <% finance = FedenaConfiguration.available_modules %>
     <% unless finance.include?("Finance") %>
       <% if permitted_to? :payslip_approve, :employee %>
         <div class="link-box">

--- a/app/views/event/show.erb
+++ b/app/views/event/show.erb
@@ -104,7 +104,7 @@
 
       <div><%= render :partial=>"event_batch" %></div>
 
-      <% @config = Configuration.available_modules%>
+      <% @config = FedenaConfiguration.available_modules%>
       <div id="select-option"></div>
       <% if @config.include?("HR") %>
         <div><%= render :partial=>"event_department" %></div>
@@ -126,4 +126,3 @@
     <% end %>
   </div>
 </div>
-

--- a/app/views/exam/report_center.html.erb
+++ b/app/views/exam/report_center.html.erb
@@ -81,7 +81,7 @@
       <div class="link-heading"><%= link_to "#{t('combined_reports')}" , :controller=> "exam",:action=>'combined_report' %></div>
       <div class="link-descr"><%= t('generates_combined_student_report') %></div>
     </div>
-    <%  if Configuration.cce_enabled? and permitted_to? :index, :cce_reports %>
+    <%  if FedenaConfiguration.cce_enabled? and permitted_to? :index, :cce_reports %>
     <div class="link-box">
       <div class="link-heading"><%= link_to "#{t('cce_reports')}" , :controller=> "cce_reports",:action=>'index' %></div>
       <div class="link-descr"><%= t('generates_combined_student_report') %></div>

--- a/app/views/exam/settings.html.erb
+++ b/app/views/exam/settings.html.erb
@@ -51,7 +51,7 @@
         <div class="link-descr"><%= t('manage_class_designations') %></div>
       </div>
     <% end %>
-    <%  if Configuration.cce_enabled? %>
+    <%  if FedenaConfiguration.cce_enabled? %>
       <%  if permitted_to? :index,:cce_settings %>
         <div class="link-box">
           <div class="link-heading"><%= link_to "#{t('cce_sttings')}" ,:controller=>'cce_settings',:action=>'index' %> </div>

--- a/app/views/exam/student_school_rank.html.erb
+++ b/app/views/exam/student_school_rank.html.erb
@@ -42,7 +42,7 @@
     <%= t('student_ranking_per_school') %>
   </div>
   <div class="box">
-    <h4><%= t('overall_school_rankings') %> : <%= Configuration.find_by_config_key("InstitutionName").config_value.present? ? Configuration.find_by_config_key("InstitutionName").config_value : "-" %></h4>
+    <h4><%= t('overall_school_rankings') %> : <%= FedenaConfiguration.find_by_config_key("InstitutionName").config_value.present? ? FedenaConfiguration.find_by_config_key("InstitutionName").config_value : "-" %></h4>
     <div id="score-table">
       <% unless @courses.empty? %>
         <% unless @students.empty? %>

--- a/app/views/exam/student_school_rank_pdf.html.erb
+++ b/app/views/exam/student_school_rank_pdf.html.erb
@@ -24,7 +24,7 @@
   <div class="extender"> </div>
   <div class="report">
     <div id ="main_info">
-      <h3 align="center"><%= t('overall_school_rankings') %> : <%= Configuration.find_by_config_key("InstitutionName").config_value.present? ? Configuration.find_by_config_key("InstitutionName").config_value : "-" %></h3>
+      <h3 align="center"><%= t('overall_school_rankings') %> : <%= FedenaConfiguration.find_by_config_key("InstitutionName").config_value.present? ? FedenaConfiguration.find_by_config_key("InstitutionName").config_value : "-" %></h3>
     </div>
     <div id="pdf-info" class="section">
       <% unless @courses.empty? %>

--- a/app/views/exam_groups/index.html.erb
+++ b/app/views/exam_groups/index.html.erb
@@ -61,7 +61,7 @@
               :style =>"display: none;" ) %></td>
         <% end %>
       </tr>
-      <% @config = Configuration.available_modules %>
+      <% @config = FedenaConfiguration.available_modules %>
       <% @exam_groups.each do |exam_group| %>
         <tr class="tr-<%= cycle('odd', 'even') %>">
           <td class="col-2">

--- a/app/views/grading_levels/_grading_levels.html.erb
+++ b/app/views/grading_levels/_grading_levels.html.erb
@@ -24,7 +24,7 @@
 <% if @batch.present?
   @credit = @batch.gpa_enabled? || @batch.cce_enabled?
 else
-  @credit = Configuration.cce_enabled? || Configuration.get_config_value('CWA')=='1' || Configuration.get_config_value('GPA')=='1'
+  @credit = FedenaConfiguration.cce_enabled? || FedenaConfiguration.get_config_value('CWA')=='1' || FedenaConfiguration.get_config_value('GPA')=='1'
 end %>
 <%  unless @grading_levels.empty? %>
   <table id="listing" align="center" width="100%" cellpadding="1" cellspacing="1">

--- a/app/views/layouts/_main_menu.html.erb
+++ b/app/views/layouts/_main_menu.html.erb
@@ -34,7 +34,7 @@
     <% @employee= @current_user.employee_record  %>
     <% @employee_subjects= @employee.subjects.collect(&:id)  %>
     <% @employee_batches=Batch.find_all_by_employee_id(@employee.id) %>
-    <% @attendance_type = Configuration.find_by_config_key('StudentAttendanceType') %>
+    <% @attendance_type = FedenaConfiguration.find_by_config_key('StudentAttendanceType') %>
     <% if @attendance_type.config_value == 'Daily' %>
       <% if permitted_to? :index, :student_attendance or @employee_batches.present? or @current_user.privileges.map{|p| p.name}.include?("StudentAttendanceView") or @current_user.privileges.map{|p| p.name}.include?("StudentAttendanceRegister") %>
         <li class="a"><%= link_to "#{t('attendance')} ▼", :controller => "student_attendance", :action => "index" %>
@@ -153,7 +153,7 @@
             <% elsif (@current_user.privileges.collect(&:name).include?('ViewResults') or (Batch.all.collect(&:employee_id).include?(@current_user.employee_record.id.to_s) if @current_user.employee?)) %>
               <li><%= link_to "Report Center" , :controller => "exam",:action=>'report_center' %></li>
             <% end %>
-            <%  if Configuration.cce_enabled? %>
+            <%  if FedenaConfiguration.cce_enabled? %>
               <%  if permitted_to? :index, :cce_reports  %>
                 <li><%= link_to "CCE Report" , :controller => "cce_reports" %>  </li>
               <% end %>

--- a/app/views/layouts/pdf_header.html.erb
+++ b/app/views/layouts/pdf_header.html.erb
@@ -22,8 +22,8 @@
     <%= wicked_pdf_image_tag "/"+(current_school_detail.logo.path||"#{Rails.root}/public/images/application/app_fedena_logo.jpg") %>
   </div>
   <div class="header-content">
-    <p><%=Configuration.get_config_value('InstitutionName'); %></p>
-    <p><%=Configuration.get_config_value('InstitutionAddress'); %></p>
+    <p><%=FedenaConfiguration.get_config_value('InstitutionName'); %></p>
+    <p><%=FedenaConfiguration.get_config_value('InstitutionAddress'); %></p>
   </div>
 
 </div>

--- a/app/views/reminder/create_reminder.erb
+++ b/app/views/reminder/create_reminder.erb
@@ -121,7 +121,7 @@
     <div id="form">
       <%= error_messages_for :reminder %>
       <%= hidden_field_tag :recipients, '' %>
-      <% @config = Configuration.available_modules  %>
+      <% @config = FedenaConfiguration.available_modules  %>
       <% if @config.include?('HR') %>
         <div class="to-options">
           <%= link_to_remote "#{t('reminder_to_staff')}", :url=>{:controller=>"reminder",:action=>"select_employee_department"},:update=>"select-employee-department", :html=>{:class=>"themed_text"} %>

--- a/app/views/scheduled_jobs/index.html.erb
+++ b/app/views/scheduled_jobs/index.html.erb
@@ -81,15 +81,15 @@
     <% end %>
     <% if @job_type.present? %>
       <% if params[:job_type].present? %>
-        <% last_completion_time_record = Configuration.find_by_config_key("job/#{@job_type}") %>
+        <% last_completion_time_record = FedenaConfiguration.find_by_config_key("job/#{@job_type}") %>
         <% if last_completion_time_record.present? %>
           <% last_completion_time = last_completion_time_record.config_value.to_time %>
         <% end %>
       <% else %>
-        <% last_completion_time = Configuration.find(:all, :conditions=>["config_key like ?","job/#{params[:job_object]}%"]).map{|t| t.config_value.to_time}.sort.last %>
+        <% last_completion_time = FedenaConfiguration.find(:all, :conditions=>["config_key like ?","job/#{params[:job_object]}%"]).map{|t| t.config_value.to_time}.sort.last %>
       <% end %>
     <% else %>
-      <% last_completion_time = Configuration.find(:all, :conditions=>["config_key like ?","job/%"]).map{|t| t.config_value.to_time}.sort.last %>
+      <% last_completion_time = FedenaConfiguration.find(:all, :conditions=>["config_key like ?","job/%"]).map{|t| t.config_value.to_time}.sort.last %>
     <% end %>
     <h5>Last Successful Completion Time : <%= last_completion_time.present? ? last_completion_time.strftime("%B %d, %Y  %r") : "-" %></h5>
     <div class="extender"></div>

--- a/app/views/student/profile.erb
+++ b/app/views/student/profile.erb
@@ -38,7 +38,7 @@
           :action => "guardians", :id => @student.id %></li>
     <% end %>
     <% if permitted_to? :email,:student %>
-      <% @config = Configuration.find_by_config_key('NetworkState').config_value %>
+      <% @config = FedenaConfiguration.find_by_config_key('NetworkState').config_value %>
       <% if @config == 'Online'  %>
         <li><%= link_to "#{t('send_email')}", :controller => "student",
             :action => "email", :id => @student.id %></li>

--- a/app/views/student/reports.erb
+++ b/app/views/student/reports.erb
@@ -63,7 +63,7 @@
   <%#= link_to "#{t('compare_past')}", { :controller => 'exam', :action => 'previous_years_marks_overview',:student=>@student.id }%>
 
         <% end %>
-        <% if Configuration.cce_enabled? %>
+        <% if FedenaConfiguration.cce_enabled? %>
           <li><%= link_to "CCE Transcript Report", { :controller => 'cce_reports', :action => 'student_transcript',:id=>@student.id }%></li>
         <% end %>
       </ul>

--- a/app/views/timetable/_extra_class_update.html.erb
+++ b/app/views/timetable/_extra_class_update.html.erb
@@ -17,7 +17,7 @@
 #specific language governing permissions and limitations
 #under the License. -%>
 
-<%  @config = Configuration.available_modules %>
+<%  @config = FedenaConfiguration.available_modules %>
 <% timing = ClassTiming.find(@period.class_timing_id) %>
 <% subject = Subject.find(@period.subject_id) unless @period.subject.nil? %>
  <div class="category-num"><%= timing.name %></div>

--- a/app/views/timetable/index.erb
+++ b/app/views/timetable/index.erb
@@ -52,7 +52,7 @@
     <%  end%>
     <%if permitted_to? :new_timetable,:timetable%>
       <div class="link-box">
-        <% @config = Configuration.available_modules %>
+        <% @config = FedenaConfiguration.available_modules %>
         <% if @config.include?('HR') %>
           <div class="link-heading"><%= link_to "#{t('create_timetable')}", :action => "new_timetable" %></div>
         <% else %>
@@ -64,7 +64,7 @@
     <%  end%>
     <%if permitted_to? :edit_master,:timetable%>
       <div class="link-box">
-        <% @config = Configuration.available_modules %>
+        <% @config = FedenaConfiguration.available_modules %>
         <% if @config.include?('HR') %>
           <div class="link-heading"><%= link_to "#{t('edit_timetable')}", :action => "edit_master" %></div>
         <% else %>

--- a/app/views/timetable/timetable_pdf.erb
+++ b/app/views/timetable/timetable_pdf.erb
@@ -53,7 +53,7 @@
                 <% else %>
                   <% period = tte.subject.nil?? " ":tte.subject.code %>
                 <% end %>
-                <% if Configuration.available_modules.include?('HR') %>
+                <% if FedenaConfiguration.available_modules.include?('HR') %>
                   <% teacher = "\n("+tte.employee.employee_number+")"    unless tte.employee.nil? %>
                   <td class="col-pdf"><%= period.upcase %><br/>
                     <% unless tte.subject.elective_group_id.present?   %>

--- a/app/views/user/dashboard.erb
+++ b/app/views/user/dashboard.erb
@@ -200,7 +200,7 @@
           </div>
         <% end %>
       <% else %>
-        <% @attendance_type = Configuration.find_by_config_key('StudentAttendanceType') %>
+        <% @attendance_type = FedenaConfiguration.find_by_config_key('StudentAttendanceType') %>
         <% unless @attendance_type.config_value == 'Daily' %>
           <div class="button-box">
             <%= link_to "<div class ='button-label'><p>#{t('attendance')}</p></div>", {:controller => "student_attendance", :action => "index"},

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,14 +20,14 @@
   {"config_key" => "DefaultCountry"                  ,"config_value" => "76"},
   {"config_key" => "FirstTimeLoginEnable"            ,"config_value" => "0"}
 ].each do |param|
-  Configuration.find_or_create_by_config_key(param)
+  FedenaConfiguration.find_or_create_by_config_key(param)
 end
 
 [
   {"config_key" => "AvailableModules"                ,"config_value" => "HR"},
   {"config_key" => "AvailableModules"                ,"config_value" => "Finance"}
 ].each do |param|
-  Configuration.find_or_create_by_config_key_and_config_value(param)
+  FedenaConfiguration.find_or_create_by_config_key_and_config_value(param)
 end
 
 if GradingLevel.count == 0

--- a/lib/auto_leave_reset.rb
+++ b/lib/auto_leave_reset.rb
@@ -17,14 +17,14 @@
 #limitations under the License.
 
 class AutoLeaveReset
-    
+
   def auto_leave_reset
-    reset_status = Configuration.find_by_config_key("AutomaticLeaveReset")
-    last_reset = Configuration.find_by_config_key("LastAutoLeaveReset")
-    reset_period = Configuration.find_by_config_key("LeaveResetPeriod")
+    reset_status = FedenaConfiguration.find_by_config_key("AutomaticLeaveReset")
+    last_reset = FedenaConfiguration.find_by_config_key("LastAutoLeaveReset")
+    reset_period = FedenaConfiguration.find_by_config_key("LeaveResetPeriod")
     if reset_status.config_value == '1'
       if last_reset.config_value.nil?
-        start_date = Configuration.find_by_config_key("FinancialYearStartDate")
+        start_date = FedenaConfiguration.find_by_config_key("FinancialYearStartDate")
         reset_date = start_date.config_value.to_date + reset_period.config_value.to_i.months
         if reset_date <= Date.today.to_date
           leave_count = EmployeeLeave.all
@@ -40,18 +40,18 @@ class AutoLeaveReset
                   available_leave = balance_leave.to_f
                   available_leave += default_leave_count.to_f
                   leave_taken = 0
-            
+
                   e.update_attributes(:leave_taken => leave_taken,:leave_count => available_leave, :reset_date => Date.today)
                 else
                   available_leave = default_leave_count.to_f
                   leave_taken = 0
-                          
+
                   e.update_attributes(:leave_taken => leave_taken,:leave_count => available_leave, :reset_date => Date.today)
                 end
               else
                 available_leave = default_leave_count.to_f
                 leave_taken = 0
-             
+
                 e.update_attributes(:leave_taken => leave_taken,:leave_count => available_leave, :reset_date => Date.today)
               end
             end
@@ -75,18 +75,18 @@ class AutoLeaveReset
                   available_leave = balance_leave.to_f
                   available_leave += default_leave_count.to_f
                   leave_taken = 0
-                          
+
                   e.update_attributes(:leave_taken => leave_taken,:leave_count => available_leave, :reset_date => Date.today)
                 else
                   available_leave = default_leave_count.to_f
                   leave_taken = 0
-       
+
                   e.update_attributes(:leave_taken => 0.0,:leave_count => available_leave, :reset_date => Date.today)
                 end
               else
                 available_leave = default_leave_count.to_f
                 leave_taken = 0
-                 
+
                 e.update_attributes(:leave_taken => 0.0,:leave_count => available_leave, :reset_date => Date.today)
               end
             end
@@ -98,4 +98,3 @@ class AutoLeaveReset
   end
 
 end
-

--- a/lib/sms_manager.rb
+++ b/lib/sms_manager.rb
@@ -68,7 +68,7 @@ class SmsManager
             message_log.sms_logs.create(:mobile=>recipient,:gateway_response=>response.body)
             if @success_code.present?
               if response.body.to_s.include? @success_code
-                sms_count = Configuration.find_by_config_key("TotalSmsCount")
+                sms_count = FedenaConfiguration.find_by_config_key("TotalSmsCount")
                 new_count = sms_count.config_value.to_i + 1
                 sms_count.update_attributes(:config_value=>new_count)
               end


### PR DESCRIPTION
The class name Configuration clashes with the
ActiveSupport::Configurable::Configuration class. This commit changes
the name but not the table name itself to avoid regression errors